### PR TITLE
ci(ci): remove extra checkout

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,9 +9,6 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
       - uses: open-turo/actions-gha/lint@v1
   action-test:
     name: Action test


### PR DESCRIPTION
The lint action performs a checkout, so the action doesn't need to do it.