### PR TITLE
ci: use renovate, update CI, precommit and automate docs

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: github-actions
-    directory: /
-    schedule:
-      interval: daily

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["github>open-turo/renovate-config#v1"]
+}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,21 +1,33 @@
-name: CI
-
+name: "CI"
 on:
   pull_request:
-    branches: [main]
+    branches:
+      - main
 
 jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: open-turo/actions-gha/lint@v1
+      - uses: open-turo/actions-gha/lint@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  # unit tests
   test:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - uses: open-turo/actions-gha/test@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  # test action works running from the graph
+  action:
+    name: Test / Action
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
       - uses: ./
         with:
           dry-run: "true"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,23 +9,41 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: open-turo/actions-gha/lint@v1
+      - uses: open-turo/actions-gha/lint@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  # unit tests
   test:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: open-turo/actions-gha/test@v1
+      - uses: open-turo/actions-gha/test@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  # test action works running from the graph
+  action:
+    name: Test / Action
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./
+        with:
+          dry-run: "true"
+          major-version: 123
+
   release:
     needs:
       - lint
       - test
+      - action
     name: Release
     runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: open-turo/actions-gha/release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: open-turo/actions-gha/release@v2

--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -1,0 +1,23 @@
+name: Update dependencies
+concurrency: update-dependencies
+
+on:
+  schedule:
+    # Every day at midnight
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+  issue_comment:
+    types:
+      - edited
+  pull_request:
+    types:
+      - edited
+
+jobs:
+  update-dependencies:
+    runs-on: ubuntu-latest
+    name: Update dependencies
+    steps:
+      - uses: open-turo/action-renovate@v1
+        with:
+          github-token: ${{ secrets.OPEN_TURO_GITHUB_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,26 +1,35 @@
+exclude: dist/.*
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0 # Use the ref you want to point at
+    rev: v4.6.0 # Use the ref you want to point at
     hooks:
       - id: check-json
       - id: check-yaml
-      - id: pretty-format-json
-        args:
-          - --autofix
       - id: end-of-file-fixer
       - id: trailing-whitespace
+  - repo: https://github.com/pre-commit/mirrors-eslint
+    rev: v9.6.0
+    hooks:
+      - id: eslint
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.5.1
+    rev: v3.1.0
     hooks:
       - id: prettier
         stages: [commit]
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
-    rev: v8.0.0
+    rev: v9.16.0
     hooks:
       - id: commitlint
         stages: [commit-msg]
         additional_dependencies: ["@open-turo/commitlint-config-conventional"]
   - repo: https://github.com/rhysd/actionlint
-    rev: v1.6.8
+    rev: v1.7.1
     hooks:
       - id: actionlint
+  - repo: local
+    hooks:
+      - id: update-action-readme
+        name: update-action-readme
+        entry: ./script/update-action-readme
+        language: script
+        files: '.*action\.yaml$'

--- a/README.md
+++ b/README.md
@@ -1,17 +1,12 @@
 # `open-turo/action-major-release`
 
+<!-- prettier-ignore-start -->
+<!-- action-docs-description source="action.yaml" -->
 ## Description
 
-GitHub Action that conditionally creates a floating branch for a major release. This is best combined with Semantic Release to provide consistent major versioning. See [open-turo/actions-gha](https://github.com/open-turo/actions-gha), which calls this from its `./release` action for example usage.
-
-[![Release](https://img.shields.io/github/v/release/open-turo/action-major-release)](https://github.com/open-turo/action-major-release/releases/)
-[![Tests pass/fail](https://img.shields.io/github/workflow/status/open-turo/action-major-release/CI)](https://github.com/open-turo/action-major-release/actions/)
-[![License](https://img.shields.io/github/license/open-turo/action-major-release)](./LICENSE)
-[![Contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg)](https://github.com/dwyl/esta/issues)
-![CI](https://github.com/open-turo/action-major-release/actions/workflows/release.yaml/badge.svg)
-[![semantic-release: angular](https://img.shields.io/badge/semantic--release-angular-e10079?logo=semantic-release)](https://github.com/semantic-release/semantic-release)
-[![Conventional commits](https://img.shields.io/badge/conventional%20commits-1.0.2-%23FE5196?logo=conventionalcommits&logoColor=white)](https://conventionalcommits.org)
-[![Join us!](https://img.shields.io/badge/Turo-Join%20us%21-593CFB.svg)](https://turo.com/jobs)
+GitHub Action that conditionally creates a floating branch for a major release
+<!-- action-docs-description source="action.yaml" -->
+<!-- prettier-ignore-end -->
 
 ## Usage
 
@@ -41,21 +36,22 @@ steps:
       dry-run: true
 ```
 
+<!-- prettier-ignore-start -->
+<!-- action-docs-inputs source="action.yaml" -->
 ## Inputs
 
-| parameter     | description                                                                                          | required | default |
-| ------------- | ---------------------------------------------------------------------------------------------------- | -------- | ------- |
-| major-version | The major version to publish. This will update the branch `v<major-version>` to the current git sha. | `true`   |         |
-| dry-run       | Whether to run the action in dry-run mode - no branches will be created or pushed.                   | `false`  | false   |
+| name | description | required | default |
+| --- | --- | --- | --- |
+| `major-version` | <p>The major version to publish. This will update the branch <code>v&lt;major-version&gt;</code> to the current git sha.</p> | `true` | `""` |
+| `dry-run` | <p>Whether to run the action in dry-run mode - no branches will be created or pushed.</p> | `false` | `false` |
+<!-- action-docs-inputs source="action.yaml" -->
+<!-- action-docs-outputs source="action.yaml" -->
 
+<!-- action-docs-outputs source="action.yaml" -->
+<!-- action-docs-runs source="action.yaml" -->
 ## Runs
 
-This action is an `composite` action.
-
-## Get Help
-
-Please review Issues, post new Issues against this repository as needed.
-
-## Contributions
-
-Please see [here](https://github.com/open-turo/contributions) for guidelines on how to contribute to this project.
+This action is a `composite` action.
+<!-- action-docs-runs source="action.yaml" -->
+<!-- action-docs-usage source="action.yaml"  -->
+<!-- prettier-ignore-end -->

--- a/script/update-action-readme
+++ b/script/update-action-readme
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -ex
+
+for i in $*; do
+  # ignore if the file does not end with /action.yaml
+  if [[ "$i" != *"action.yaml" ]]; then
+    echo "skipping: ${i}"
+    continue
+  fi
+  readme_file=$(dirname "$i")/README.md
+  echo "npx action-docs --no-banner -a "${i}" --update-readme "${readme_file}""
+  npx action-docs@2 --no-banner -a "${i}" --update-readme "${readme_file}"
+done


### PR DESCRIPTION

**Description**

Going through open PRs in open-turo I realized that this repo was way out of date. This PR updates most of things to use our latest standards.

**Changes**

* ci: use renovate, update CI, precommit and automate docs

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
