### PR TITLE
feat: create a tag as well for the floating version

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -16,13 +16,17 @@ runs:
       shell: bash
       run: |
         echo "Updating branch: v${{ inputs.major-version }}"
-        git branch -f v${{ inputs.major-version }}
-        git push -f origin v${{ inputs.major-version }}
+        git tag -f v${{ inputs.major-version }}
+        git brach -f v${{ inputs.major-version }}
+        git push -f origin refs/tags/v${{ inputs.major-version }}
+        git push -f origin refs/heads/v${{ inputs.major-version }}
     - name: "Dry-run: Create and push branch"
       if: inputs.dry-run == 'true'
       shell: bash
       run: |
         echo "Updating branch: v${{ inputs.major-version }}"
         echo "  (dry-run)"
-        echo "git branch -f v${{ inputs.major-version }}"
-        echo "push -f origin v${{ inputs.major-version }}"
+        echo "git tag -f v${{ inputs.major-version }}"
+        echo "git brach -f v${{ inputs.major-version }}"
+        echo "git push -f origin refs/tags/v${{ inputs.major-version }}"
+        echo "git push -f origin refs/heads/v${{ inputs.major-version }}"


### PR DESCRIPTION
**Description**

For better tool compatibility as tools like renovatebot don't support floating branches. See https://github.com/open-turo/action-major-release/pull/24

I did some soft tests and pushing both the tag and the branch worked fine.

The only reason to keep the branch is for backwards compatibility
**Changes**

* feat: create a tag as well for the floating version

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
